### PR TITLE
Set Connection auto commit to false

### DIFF
--- a/xsk/db/db.js
+++ b/xsk/db/db.js
@@ -209,6 +209,8 @@ function XscCallableStatement(callableStatement) {
 }
 
 function XscConnection(dConnection) {
+	dConnection.setAutoCommit(false);
+	
 	this.close = function () {
 		dConnection.close();
 	};

--- a/xsk/hdb/hdb.js
+++ b/xsk/hdb/hdb.js
@@ -29,6 +29,8 @@ exports.ProcedureResult = function () {
 exports.ResultSet = XscResultSet;
 
 function XscConnection(dConnection) {
+	dConnection.setAutoCommit(false);
+	
 	this.close = function () {
 		dConnection.close();
 	};


### PR DESCRIPTION
Change $.db/$.hdb API to return connection with default autocommit mode set to false, as it was in XSC - https://help.sap.com/doc/3de842783af24336b6305a3c0223a369/1.0.12/en-US/$.hdb.Connection.html